### PR TITLE
[DO NOT MERGE] Performance stuffs

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime/pprof"
 	"strings"
 	"text/tabwriter"
 )
@@ -35,6 +36,13 @@ func init() {
 }
 
 func main() {
+	f, err := os.Create("gtx_buf_writer_parallel_branch.prof")
+	if err != nil {
+		log.Fatal(err)
+	}
+	pprof.StartCPUProfile(f)
+	defer pprof.StopCPUProfile()
+
 	opt := &options{
 		config: ".jimmy.json",
 	}
@@ -186,7 +194,6 @@ func main() {
 	}
 
 	pro.updateBranches(branches)
-
 	pro.writePages(branches)
 	pro.writeMainIndex(branches)
 }

--- a/main.go
+++ b/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/url"
 	"os"
@@ -140,7 +142,7 @@ func main() {
 	// The repo flag is required at this point.
 	if ok := filepath.IsAbs(opt.Source); ok {
 		// Option considered repo-like if it contains a hidden `.git` dir.
-		if _, err := os.Stat(filepath.Join(opt.Source, ".git")); os.IsNotExist(err) {
+		if _, err := os.Stat(filepath.Join(opt.Source, ".git")); errors.Is(err, fs.ErrNotExist) {
 			flag.Usage()
 			os.Exit(1)
 		}

--- a/performance.md
+++ b/performance.md
@@ -1,0 +1,272 @@
+```
+      4      3 write(0x7, "\n    </header>\n    <main>\n      <hr>\0", 0x24)		 = 36 0
+     37      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      8      5 write(0x7, "\n      <table>\n        <tr>\0", 0x1B)		 = 27 0
+     33      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      8      6 write(0x7, "<td>\n            <pre>\0", 0x16)		 = 22 0
+      6      4 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      6      4 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      6      4 write(0x7, "1\0", 0x1)		 = 1 0
+     50      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "1\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, "  1\0", 0x3)		 = 3 0
+     33      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      2 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+     26      2 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "2\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "2\0", 0x1)		 = 1 0
+     31      2 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, "  2\0", 0x3)		 = 3 0
+      4      3 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      3 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+     32      2 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "3\0", 0x1)		 = 1 0
+     31      2 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "3\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, "  3\0", 0x3)		 = 3 0
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      5      4 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+     52      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "4\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      5      3 write(0x7, "4\0", 0x1)		 = 1 0
+     36      5 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, "  4\0", 0x3)		 = 3 0
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      2 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      6      5 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      3 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      5      3 write(0x7, "5\0", 0x1)		 = 1 0
+      4      3 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+     35      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, "5\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, "  5\0", 0x3)		 = 3 0
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      3 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "6\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+     35      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, "6\0", 0x1)		 = 1 0
+      5      4 write(0x7, "\">\0", 0x2)		 = 2 0
+      5      3 write(0x7, "  6\0", 0x3)		 = 3 0
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "7\0", 0x1)		 = 1 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      5      3 write(0x7, "7\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      5      3 write(0x7, "  7\0", 0x3)		 = 3 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      2 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      3 write(0x7, ".html#L\0", 0x7)		 = 7 0
+     33      2 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "8\0", 0x1)		 = 1 0
+      5      3 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "8\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, "  8\0", 0x3)		 = 3 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      3 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, "9\0", 0x1)		 = 1 0
+      6      4 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "9\0", 0x1)		 = 1 0
+      4      2 write(0x7, "\">\0", 0x2)		 = 2 0
+     34      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "  9\0", 0x3)		 = 3 0
+      5      3 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      3 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+     35      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "10\0", 0x2)		 = 2 0
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+      4      3 write(0x7, "10\0", 0x2)		 = 2 0
+     35      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "\">\0", 0x2)		 = 2 0
+      5      3 write(0x7, " 10\0", 0x3)		 = 3 0
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      2 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+     34      3 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      2 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      5      3 write(0x7, "11\0", 0x2)		 = 2 0
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+     35      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "11\0", 0x2)		 = 2 0
+      6      4 write(0x7, "\">\0", 0x2)		 = 2 0
+      4      3 write(0x7, " 11\0", 0x3)		 = 3 0
+      4      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+      4      2 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+     37      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      5      3 write(0x7, ".html#L\0", 0x7)		 = 7 0
+      5      3 write(0x7, "12\0", 0x2)		 = 2 0
+      4      2 write(0x7, "\" id=\"L\0", 0x7)		 = 7 0
+     36      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "12\0", 0x2)		 = 2 0
+      5      3 write(0x7, "\">\0", 0x2)		 = 2 0
+      5      3 write(0x7, " 12\0", 0x3)		 = 3 0
+      5      2 write(0x7, "</a><br>\0", 0x8)		 = 8 0
+     37      4 __semwait_signal(0x1F03, 0x0, 0x1)		 = -1 Err#60
+      5      3 write(0x7, "<a href=\"object/\0", 0x10)		 = 16 0
+      4      3 write(0x7, "22/5a628ea0029a8067b87edae8291c6b58eba387\0", 0x29)		 = 41 0
+      4      3 write(0x7, ".html#L\0", 0x7)		 = 7 0
+```
+
+before:
+```
+CALL                                        COUNT
+access                                          1
+bsdthread_register                              1
+csops                                           1
+exit                                            1
+fstatat64                                       1
+getattrlist                                     1
+getpid                                          1
+getrlimit                                       1
+issetugid                                       1
+kqueue                                          1
+mkdir                                           1
+proc_info                                       1
+setitimer                                       1
+shm_open                                        1
+sysctlbyname                                    1
+__mac_syscall                                   2
+csops_audittoken                                2
+csrctl                                          2
+getfsstat64                                     2
+ioctl                                           2
+openat                                          2
+shared_region_check_np                          2
+dup                                             3
+ulock_wait                                      3
+ulock_wake                                      3
+fsgetpath                                       4
+munmap                                          6
+bsdthread_create                                7
+thread_selfid                                   7
+__pthread_canceled                              8
+sysctl                                          8
+mprotect                                       15
+sigaltstack                                    16
+mmap                                           29
+sigaction                                      50
+psynch_cvclrprepost                            69
+link                                          184
+psynch_mutexdrop                              195
+psynch_mutexwait                              197
+__pthread_kill                                284
+fork                                          570
+wait4_nocancel                                678
+madvise                                       954
+fstat64                                      1036
+open                                         1042
+sigreturn                                    1230
+pipe                                         1727
+__pthread_sigmask                            1739
+psynch_cvsignal                              4315
+close                                        4563
+psynch_cvwait                                4723
+read                                         5111
+stat64                                       5610
+kevent                                       9174
+fcntl                                       10351
+__semwait_signal                            26300
+write                                       97143
+```
+
+```
+spike@Spikes-MBP /tmp % sudo dtruss -coe ./gtx -s ~/src/github.com/thewhodidthis/jimmy -b develop -b main
+ ELAPSD    CPU SYSCALL(args) 		 = return
+```
+
+after:
+```
+CALL                                        COUNT
+access                                          1
+bsdthread_register                              1
+csops                                           1
+fstatat64                                       1
+getattrlist                                     1
+getpid                                          1
+getrlimit                                       1
+issetugid                                       1
+kqueue                                          1
+mkdir                                           1
+proc_info                                       1
+shm_open                                        1
+sysctlbyname                                    1
+__mac_syscall                                   2
+csops_audittoken                                2
+csrctl                                          2
+getfsstat64                                     2
+ioctl                                           2
+openat                                          2
+setitimer                                       2
+shared_region_check_np                          2
+dup                                             3
+fsgetpath                                       4
+bsdthread_create                                5
+thread_selfid                                   5
+munmap                                          6
+sysctl                                          8
+ulock_wait                                     10
+ulock_wake                                     10
+sigaltstack                                    12
+mprotect                                       15
+mmap                                           32
+__pthread_canceled                             50
+sigaction                                      50
+psynch_cvclrprepost                            97
+psynch_mutexdrop                              444
+psynch_mutexwait                              448
+link                                          497
+__pthread_kill                                881
+fork                                         1210
+wait4_nocancel                               1387
+write                                        1660
+fstat64                                      2373
+open                                         2384
+sigreturn                                    2611
+__pthread_sigmask                            3649
+pipe                                         3651
+madvise                                      3678
+close                                        9701
+psynch_cvsignal                              9807
+read                                        10186
+psynch_cvwait                               10734
+stat64                                      12110
+kevent                                      19467
+fcntl                                       21895
+__semwait_signal                            56165
+```

--- a/project.go
+++ b/project.go
@@ -3,9 +3,11 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
@@ -146,7 +148,6 @@ func (p *project) processObject(obj object, base string, br branch, c commit) {
 func (p *project) writeMainIndex(branches []branch) {
 	// This is the main index or project home.
 	f, err := os.Create(filepath.Join(p.base, "index.html"))
-
 	defer f.Close()
 
 	if err != nil {
@@ -178,8 +179,8 @@ func (p *project) writeCommitDiff(base string, b branch, c commit, parent string
 	}
 
 	dst := filepath.Join(base, fmt.Sprintf("diff-%s.html", parent))
-	f, err := os.Create(dst)
 
+	f, err := os.Create(dst)
 	defer f.Close()
 
 	if err != nil {
@@ -245,7 +246,6 @@ func (p *project) writeObjectBlob(obj object, dst string) {
 	}
 
 	f, err := os.Create(dst)
-
 	defer f.Close()
 
 	if err != nil {
@@ -327,8 +327,7 @@ func (p *project) writeNom(nom string, base string, b branch, c commit, obj obje
 	}
 
 	if err := os.Link(nom, lnk); err != nil {
-		// TODO(spike): this line below looks fishy
-		if os.IsExist(err) {
+		if errors.Is(err, fs.ErrExist) {
 			return
 		}
 		log.Printf("unable to hard link object into commit folder: %v", err)
@@ -338,8 +337,8 @@ func (p *project) writeNom(nom string, base string, b branch, c commit, obj obje
 
 func (p *project) writeCommitPage(base string, b branch, c commit) {
 	dst := filepath.Join(base, "index.html")
-	f, err := os.Create(dst)
 
+	f, err := os.Create(dst)
 	defer f.Close()
 
 	if err != nil {

--- a/project.go
+++ b/project.go
@@ -113,6 +113,13 @@ func (p *project) processBranch(br branch) {
 func (p *project) processCommit(br branch, c commit) {
 	base := filepath.Join(p.base, "commit", c.Hash)
 
+  // Commits don't change.  If the directory already exists, it is up
+  // to date and we can save some work.
+	if _, err := os.Stat(base); err == nil || errors.Is(err, fs.ErrExist) {
+		log.Printf("commit %v already processed", c.Abbr)
+		return
+	}
+
 	if err := os.MkdirAll(base, 0755); err != nil {
 		if err != nil {
 			log.Printf("unable to create commit directory: %v", err)


### PR DESCRIPTION
* Adds profiling code, you can change the profile's filename by changing 
https://github.com/thewhodidthis/gtx/blob/28573dcc65585a7e6cd184df24d5d560f3800dae/main.go#L41
(I'd normally put this behind a flag but I was lazy)

* Once you have a profile, you can look at it with 
```
go tool pprof -http=localhost:6060 gtx_buf_writer_parallel_branch.prof
```

* I noticed initially that most of the time was spent in `syscall.syscall` so used `dtruss` (the `strace` equivalent on OSX) to have a look at what's happening. Turns out calling `Write` on the file handle returned directly from `os.Create` writes line-by-line, which resulted in A LOT of syscalls to `write(2)`:

https://github.com/thewhodidthis/gtx/blob/28573dcc65585a7e6cd184df24d5d560f3800dae/performance.md?plain=1#L205

Wrapping those calls in a buffered writer reduced the number of calls significantly:

https://github.com/thewhodidthis/gtx/blob/28573dcc65585a7e6cd184df24d5d560f3800dae/project.go#L367-L373

https://github.com/thewhodidthis/gtx/blob/28573dcc65585a7e6cd184df24d5d560f3800dae/performance.md?plain=1#L257

But also didn't really improve performance 🙃 I got distracted by something else before going in much deeper but it looks like the Go runtime holds a lock somewhere related to creating new file handles, which is probably where the bottleneck is - since every action creates and writes to a file, adding concurrency just bottlenecks harder.

I added in a small check from the original `git2html`, which speeds things up a bit by reducing redundant work:

https://github.com/thewhodidthis/gtx/blob/28573dcc65585a7e6cd184df24d5d560f3800dae/project.go#L116-L121

lifted from here:

https://github.com/Hypercubed/git2html/blob/b29cc9517980058cce3f550c4befcf73ee8147bc/git2html.sh#L373-L380

But, this wasn't very satisfying as there are some bits of this that _should_ be possible to speed up with goroutines. I might come back to this at some point but was a fun hour or so poking around :)

